### PR TITLE
Fix bootstrap of xapian-letor

### DIFF
--- a/xapian-letor/Makefile.am
+++ b/xapian-letor/Makefile.am
@@ -50,7 +50,7 @@ libxapianletor_la_SOURCES = $(lib_src)
 libxapianletor_la_LDFLAGS = \
 	$(XAPIAN_LDFLAGS) -no-undefined -version-info $(LIBRARY_VERSION_INFO)
 
-libxapianletor_la_LIBADD = $(XAPIAN_LIBS)
+libxapianletor_la_LIBADD = $(XAPIAN_LIBS) libcommon_str.la
 
 lib_src =
 
@@ -67,9 +67,6 @@ include scorer/Makefile.mk
 
 noinst_LTLIBRARIES += libcommon_str.la
 libcommon_str_la_SOURCES = common/str.cc
-
-lib_src +=\
-	libcommon_str.la
 
 xapianletorinclude_HEADERS += include/xapian-letor/letor_error.h
 

--- a/xapian-letor/Makefile.am
+++ b/xapian-letor/Makefile.am
@@ -65,6 +65,12 @@ include feature/Makefile.mk
 include ranker/Makefile.mk
 include scorer/Makefile.mk
 
+noinst_LTLIBRARIES += libcommon_str.la
+libcommon_str_la_SOURCES = common/str.cc
+
+lib_src +=\
+	libcommon_str.la
+
 xapianletorinclude_HEADERS += include/xapian-letor/letor_error.h
 
 if MAINTAINER_MODE

--- a/xapian-letor/api/Makefile.mk
+++ b/xapian-letor/api/Makefile.mk
@@ -9,5 +9,4 @@ lib_src +=\
 	api/featurelist.cc\
 	api/featurevector.cc\
 	api/letor.cc\
-	api/letor_internal.cc\
-	common/str.cc
+	api/letor_internal.cc

--- a/xapian-letor/bin/Makefile.mk
+++ b/xapian-letor/bin/Makefile.mk
@@ -6,9 +6,8 @@ bin_PROGRAMS +=\
 
 bin_xapian_letor_update_SOURCES =\
 	bin/xapian-letor-update.cc\
-	common/getopt.cc\
-	common/str.cc
-bin_xapian_letor_update_LDADD = $(XAPIAN_LIBS)
+	common/getopt.cc
+bin_xapian_letor_update_LDADD = $(XAPIAN_LIBS) libcommon_str.la
 
 bin_xapian_prepare_trainingfile_SOURCES =\
 	bin/xapian-prepare-trainingfile.cc\


### PR DESCRIPTION
Put common/str.cc into its own convenience library (libcommon_str.la)
and link that into the library and into the binary which needs it.
This avoids automake failing because it wants to compile common/str.cc
twice with different options to the same object file.
